### PR TITLE
Option --vars for including JSON file with global variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ restcli --full myrequest.http
 
 # Disable colour.
 restcli --no-color myrequest.http
+
+# Use global variables from JSON file, f.x. {"endpoint": "https://example.com"}
+restcli --vars path/to/env-vars.json myrequest.http
 ```
 
 
@@ -58,10 +61,10 @@ import { RestParser } from 'rest-cli';
 (async () => {
     const parser = new RestParser();
     await parser.readFile("./myrequest.http");
-    
+
     const request = await parser.get(0);
     console.log(request.toString());
-    
+
     const { response } = await request.request();
     console.log(response.getBody());
 })();

--- a/src/RestParser.ts
+++ b/src/RestParser.ts
@@ -8,15 +8,26 @@ import { StringMap } from './utils';
 
 type Step = "init" | "request" | "body" | "file";
 
+export interface RestParserOptions {
+    globalVars?: Map<string,string>;
+}
 
 export class RestParser {
 
     files: RestFile[];
     count: number;
+    globalVars: Map<string,string>|null;
 
-    constructor() {
+    constructor(options?: RestParserOptions) {
         this.files = [];
         this.count = 0;
+
+        // Optional global (environment) variables
+        if (typeof(options) !== 'undefined' && typeof(options.globalVars) !== 'undefined') {
+            this.globalVars = options.globalVars;
+        } else {
+            this.globalVars = null;
+        }
     }
 
     public async get(name: string | number): Promise<RestRequest | null> {
@@ -52,6 +63,13 @@ export class RestParser {
         const vars = new VarMap();
         const names: string[] = [];
         const requests: RestRequest[] = [];
+
+        // Assign global variables as they would be in the file header
+        if (this.globalVars !== null) {
+            this.globalVars.forEach((value, key) => {
+                vars.addVar(key, value);
+            });
+        }
 
         for (let part of contents.split(/###+.*\n/)) {
             let step: Step = "init";

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -11,10 +11,23 @@ const TEST_FILE = r("test.http");
 test("RestParser: read", assert => {
     const parser = new RestParser();
     assert.equals(parser.isEmpty(), true);
-    
+
     parser.readString(TEST_FILE, fs.readFileSync(TEST_FILE, "utf-8"));
     assert.equals(parser.isEmpty(), false);
-    
+
+    assert.end();
+});
+
+test("RestParser: global variables", assert => {
+    const globalVars = new Map<string,string>();
+    globalVars.set('varName', 'varValue');
+
+    const parser = new RestParser({ globalVars });
+    assert.equals(parser.globalVars, globalVars, 'global vars are stored in rest parser');
+
+    parser.readString(TEST_FILE, fs.readFileSync(TEST_FILE, "utf-8"));
+    assert.equals(parser.files[0].vars.variables.varName, 'varValue', 'rest file contains global vars');
+
     assert.end();
 });
 
@@ -25,4 +38,3 @@ test("RestParser: read", assert => {
 // @todo Test get(index)
 
 // @todo Test get(name)
- 


### PR DESCRIPTION
Added `--vars path/to/env-vars.json` option so you can include global variables added to all included files. They may be overridden by file as they are added as they would exists in the beginning of file.