### PR TITLE
Non-zero exit code if there is an error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -147,6 +147,8 @@ export async function main(argv = process.argv) {
         if (isServerError(error)) {
             console.log(chalk.red(await error.response.text()));
         }
+
+        process.exitCode = 1;
     }
 }
 


### PR DESCRIPTION
If anyone would like to use this tool in CI/CD they would miss information if requests have succeeded. CI/CD workers detect job failure if process returned non-zero exit code. This changes set exitCode to 1 if any of requests failed.